### PR TITLE
feat: 관리자 승인 API 추가

### DIFF
--- a/profiles/models.py
+++ b/profiles/models.py
@@ -32,8 +32,8 @@ class Profile(models.Model):
 class MentorVerification(models.Model):
     user = models.OneToOneField(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     introduction = models.TextField(blank=True)
-    document = models.FileField(upload_to='mentor_docs/', blank=True, null=True)  # 📌 핵심
-    is_verified = models.BooleanField(default=False)
+    document = models.FileField(upload_to='mentor_docs/', blank=True, null=True)  
+    is_verified = models.BooleanField(default=False)#관리자가 True로 설정해야지 멘토 인증 완료
 
     is_skipped = models.BooleanField(default=False)
 

--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import InterestSelectionView, AgreementView, MentorVerificationView, skip_mentor_verification
+from .views import InterestSelectionView, AgreementView, MentorVerificationView, skip_mentor_verification, MentorVerificationApproveView
 
 urlpatterns = [
     path('interests/', InterestSelectionView.as_view(), name='interest-select'),
     path('agreements/', AgreementView.as_view(), name='agreement'),
     path('mentor-verification/', MentorVerificationView.as_view(), name='mentor-verification'),
     path('mentor-verification/skip/', skip_mentor_verification, name='skip_mentor_verification'),
+    path('mentor-verification/<int:user_id>/verify/', MentorVerificationApproveView.as_view()),
 ]

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -61,3 +61,15 @@ def skip_mentor_verification(request):
 
     MentorVerification.objects.create(user=user, is_skipped=True)
     return Response({"message": "멘토 인증 건너뛰기 완료"}, status=200)
+
+#멘토 인증 관리자 승인
+
+class MentorVerificationApproveView(APIView):
+    def put(self, request, user_id):
+        try:
+            verification = MentorVerification.objects.get(user__id=user_id)
+            verification.is_verified = True
+            verification.save()
+            return Response({"message": "멘토 인증이 승인되었습니다."}, status=status.HTTP_200_OK)
+        except MentorVerification.DoesNotExist:
+            return Response({"error": "해당 유저의 인증 정보가 없습니다."}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
related to #1

## 📌 작업 내용
- 멘토 인증 요청 후 관리자가 수락하는 승인 로직 추가

## 🔍 작업 상세
- [x] 관리자 승인 API

## 🧪 테스트 결과
- [x] 로컬 테스트 완료
<img width="658" alt="image" src="https://github.com/user-attachments/assets/640af8f8-17f3-4e29-9c5b-569ffaab82ea" />
<img width="387" alt="image" src="https://github.com/user-attachments/assets/2f1f3dcd-3887-47d6-bd82-b96063eb5765" />
<img width="733" alt="image" src="https://github.com/user-attachments/assets/32478a35-81d6-4871-8eff-aafc614b0d16" />


## 🗨 기타 참고 사항
- 이슈 번호: `#1`
- 논의가 필요한 부분이 있다면 여기에 작성해주세요.
